### PR TITLE
Search pull requests and fix parse bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@ npm1k.org
 =========
 
 Are we licensed yet?
+
+Running
+-------
+
+Specify a valid [GitHub token](https://github.com/settings/tokens) in the
+`GITHUB_TOKEN` environment variable so the default branch and pull requests can
+be searched for valid licenses as well.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "cheerio": "^0.19.0",
+    "github-package-json": "^2.1.0",
     "github-url-to-object": "^1.5.2",
     "jscs": "^1.13.1",
     "jshint": "^2.7.0",

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,8 +37,9 @@
         <thead>
           <tr>
             <th>№</th>
-            <th>Fix It!</th>
             <th>Package</th>
+            <th>Fix It!</th>
+            <th>Notes</th>
             <th>package.json license property</th>
           </tr>
         </thead>
@@ -47,6 +48,7 @@
           {{#mostWanted}}
           <tr>
             <td>{{number}}</td>
+            <td><a href='{{homepage}}'>{{package}}</a></td>
             <td>
               {{#fixItURL}}
                 <a href='{{fixItURL}}'>
@@ -54,7 +56,19 @@
                 </a>
               {{/fixItURL}}
             </td>
-            <td><a href='{{homepage}}'>{{package}}</a></td>
+            <td>
+              {{#fixedInRepo}}
+                fixed but not published
+              {{/fixedInRepo}}
+
+              {{#fixedInPRs.length}}
+                fixed in
+
+                {{#fixedInPRs}}
+                  <a href="{{url}}">#{{number}}</a>
+                {{/fixedInPRs}}
+              {{/fixedInPRs.length}}
+            </td>
             <td>{{license}}</td>
           </tr>
           {{/mostWanted}}


### PR DESCRIPTION
I actually managed to implement both pieces of #2. :sparkles:
- package.json in the default branch is now searched for a valid license
- if package.json appears in any pull requests they're searched for a valid license
- `github-url-to-object` does't handle URLs like 'git+ssh://' correctly so I strip off 'git+' from the beginning

I tried to keep a similar code style but did find it necessary to break things out into functions to understand what was going on. I also opted for (slightly) more vertical whitespace in the code I added but let me know if you want that removed. :)

You can [see how it looks here](https://beaugunderson.com/npm1k.html). Note that the pull request links are wrong in that version (they're API links there) but if you regenerate (after putting a token in your environment in `GITHUB_TOKEN`) you'll see the correct URLs. I'll also regenerate it as soon as my rate limit resets (it takes ~3,500 calls and you get 5,000 an hour).
